### PR TITLE
[FEAT] carousel에서 페스티벌 데이터를 출력한다.

### DIFF
--- a/src/components/Carousel.jsx
+++ b/src/components/Carousel.jsx
@@ -1,6 +1,7 @@
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Pagination, Autoplay } from "swiper/modules";
 import { useFestivalStore } from "../store/festivalStore";
+import { useState } from "react";
 import styled from "styled-components";
 import "swiper/css";
 import "swiper/css/pagination";
@@ -8,9 +9,20 @@ import "swiper/css/pagination";
 const Carousel = () => {
   const { festivalData } = useFestivalStore();
   const swiperData = festivalData.slice(3, 8);
+  const [info, setInfo] = useState(swiperData[0]);
+
+  const activeEventInfo = (swiper) => {
+    console.log(swiper.realIndex);
+    setInfo(swiperData[swiper.realIndex]);
+  };
 
   return (
     <Container>
+      <FestivalInfo>
+        <h1>{info.TITLE}</h1>
+        <p>{info.DATE}</p>
+        <p>{info.PLACE}</p>
+      </FestivalInfo>
       <StyledSwiper
         modules={[Pagination, Autoplay]}
         slidesPerView={1}
@@ -24,6 +36,7 @@ const Carousel = () => {
           disableOnInteraction: false,
         }}
         speed={800}
+        onSlideChange={activeEventInfo}
         className="mySwiper"
       >
         {swiperData.map(({ MAIN_IMG, TITLE }, index) => (
@@ -39,6 +52,8 @@ const Container = styled.div`
   height: 500px;
   padding: 50px 0;
 `;
+
+const FestivalInfo = styled.div``;
 
 // Swiper 기본 스타일
 const DefaultSwiper = styled(Swiper)`


### PR DESCRIPTION
## 🏷️ 관련 이슈
#14 

### ✨ PR 타입
- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] etc

### 반영 브랜치
feat/carousel -> develop

### 📜 작업 내용
- carousel에서 페스티벌 포스터를 보여준다.
-  carousel에서 페스티벌 정보를 표시한다. (타이틀, 날짜, 장소)


### ✅ 테스트
<img width="1376" alt="스크린샷 2024-11-28 오후 7 22 15" src="https://github.com/user-attachments/assets/5d9935e6-6926-42c5-8757-fa4529eeea5d">



### 📮 ETC
- 참고사항 있으면 작성해주세요

